### PR TITLE
Debug which files are using module

### DIFF
--- a/core/src/comparer.js
+++ b/core/src/comparer.js
@@ -1,14 +1,26 @@
 'use strict';
 
-var Promises = require('bluebird'), 
+var Promises = require('bluebird'),
 	colorizer = require('./colorizer'),
-	adapter = require('./adapter');
+	adapter = require('./adapter'),
+	path = require('path'),
+	DEFAULT_NODE_MODULES = ['url', 'cluster', 'domain', 'path', 'fs', 'http', 'util'];
 
 function diff (arr, diff){
     return arr.filter(function(i) {return diff.indexOf(i) < 0;});
 }
 
-function Compare (root, requires) {
+function debug(log,  options, dependency) {
+	if (!options.debug)
+		return;
+	var files = (options.where[dependency] || []).map(path.relative.bind(path, options.root));
+	log.push('     => ' + (files).join('\n     => ') + '\n');
+}
+
+function Compare (root, requires, options) {
+	options = options || {};
+	options.debug = options.debug || false;
+	options.root = root;
 	return new Promises(function(resolve, reject) {
 		var pJson = require(root + '/package.json');
 		var log = [],
@@ -37,7 +49,7 @@ function Compare (root, requires) {
 
 
 		/* Dependency Comparator */
-		var gruntDependencies = dependencies.filter(function(item){ 
+		var gruntDependencies = dependencies.filter(function(item){
 			if (item.indexOf('grunt') >= 0) return true });
 
 		if (gruntDependencies.length > 0) {
@@ -57,7 +69,7 @@ function Compare (root, requires) {
 			})
 		}
 
-		dependencies = dependencies.filter(function(item){ 
+		dependencies = dependencies.filter(function(item){
 			if (item.indexOf('grunt') === -1) return true });
 
 		dependencies.forEach(function(dependency) {
@@ -66,15 +78,19 @@ function Compare (root, requires) {
 				unusedLog.push(colorizer('error', '  • ') + dependency)
 			} else {
 				successLog.push(colorizer('success', '  • ') + dependency)
+				debug(successLog, options, dependency);
 			}
 		});
 
 		var unused = diff(dependencies, requires);
 
 		var differences = diff(requires, dependencies);
+		differences = diff(differences, DEFAULT_NODE_MODULES);
+
 		if (differences.length > 0) {
 			differences.forEach(function(diff) {
 				undefinedLog.push(colorizer('error', '  • ') + diff)
+				debug(undefinedLog, options, diff);
 			})
 		}
 
@@ -90,7 +106,7 @@ function Compare (root, requires) {
 
 		if (undefinedLog.length > 0) {
 			log.push(colorizer('error','\n Undefined, but used:'))
-			log.push(undefinedLog.join('\n'))	
+			log.push(undefinedLog.join('\n'));
 		}
 
 		resolve([differences, unused, dependencies, log.join('\n')]);

--- a/core/src/formater.js
+++ b/core/src/formater.js
@@ -4,7 +4,7 @@ function Formater(arr) {
   var newArr = [];
   if (typeof arr === 'object') {
   	arr.forEach(function(item, index) {
-  		if (/^[A-Za-z0-9\s_-]+$/.test(item))
+  		if (/^[A-Za-z0-9\s\\._-]+$/.test(item))
   			newArr.push(item);
   	});
 

--- a/core/src/searcher.js
+++ b/core/src/searcher.js
@@ -11,8 +11,9 @@ function Searcher (paths) {
 };
 
 function search (paths) {
-    var requires = new Array();
-    var validPaths = new Array();
+    var requires = [];
+    var validPaths = [];
+    var where = {};
 
     paths.forEach(function(path){
         if (path.indexOf('node_modules/') === -1) {
@@ -31,6 +32,8 @@ function search (paths) {
                     if ((dependency.indexOf('/') == -1) && (dependency.indexOf('.js') == -1)) {                        if (apiNode.indexOf(dependency) == -1) {
                             requires.push(dependency);
                             validPaths.push(path);
+                            where[dependency] = where[dependency] || []
+                            where[dependency].push(path);
                         }
                     }
                 });
@@ -38,7 +41,7 @@ function search (paths) {
         }
     });
 
-    return {'requires': requires, 'validPaths': validPaths};
+    return {'requires': requires, 'validPaths': validPaths, where: where};
 }
 
 module.exports = Searcher;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,8 +13,11 @@ else if (verify(['-h', '--help']))
 else if (typeof commands[2] != 'undefined') {
 
 	// Status
-	if (commands.indexOf('status') > -1)
+	if (commands.indexOf('status') > -1) {
+        if (commands.indexOf('-d') > -1 || commands.indexOf('--debug') > -1)
+            ranza.setDebug();
     	return ranza.exec();
+    }
 
     // Clean
 	if (commands.indexOf('clean') > -1) 

--- a/lib/ranza.js
+++ b/lib/ranza.js
@@ -60,7 +60,6 @@ Ranza.prototype.exec = function() {
     r.sentinel('/').spread(function(files, root){
         var searcher = r.searcher(files),
             requires = r.formater(searcher['requires']);
-            console.log(self.debug);
         return r.compare(root, requires, {debug: self.debug, where: searcher.where})
             .spread(function(diffs, unused, reqs, log) {
                 console.log(log + '\n');

--- a/lib/ranza.js
+++ b/lib/ranza.js
@@ -29,8 +29,8 @@ Ranza.prototype.watch = function(install) {
         var searcher = r.searcher(files),
             paths = searcher['validPaths'];
 
-        console.log('[RANZA WATCHING]'); 
-        console.log(colorizer('success', '\nlivereload...\n')); 
+        console.log('[RANZA WATCHING]');
+        console.log(colorizer('success', '\nlivereload...\n'));
 
         watch(paths, function(filename) {
             var searcher = r.searcher(files),
@@ -38,7 +38,7 @@ Ranza.prototype.watch = function(install) {
 
             if (!installFlag){
                 installFlag = true;
-                r.compare(root, requires, false).spread(function(diffs) {
+                r.compare(root, requires).spread(function(diffs) {
                     if (diffs.length <= 0) {
                         installFlag = false;
                         return console.log(colorizer('message','Ranza says: There is no unidentified requires!\n'));
@@ -79,7 +79,7 @@ Ranza.prototype.install = function(install) {
         return r.manager('install', root, requires, save, true);
 
     }).catch(function(err){
-        console.log(colorizer('error', 'Ranza: ' + err )); 
+        console.log(colorizer('error', 'Ranza: ' + err ));
     })
 }
 
@@ -89,7 +89,7 @@ Ranza.prototype.clean = function(removeType) {
         var searcher = r.searcher(files),
             requires = r.formater(searcher['requires']);
 
-        r.compare(root, requires, false).spread(function(diffs, unused) {
+        r.compare(root, requires).spread(function(diffs, unused) {
             if (unused.length <= 0)
                 return console.log(colorizer('message','\nRanza says: There is no unused dependencies!\n'));
 

--- a/lib/ranza.js
+++ b/lib/ranza.js
@@ -7,7 +7,10 @@ var pJson = require('../package.json'),
     colorizer = r.colorizer;
 
 var Ranza = function() {};
-    
+Ranza.prototype.setDebug = function(debug) {
+    this.debug = (typeof(debug) === 'undefined' ? true : debug);
+    return ('Debug enabled');
+}
 Ranza.prototype.default = function() {
     return r.reader('/../docs/default.md')
 }
@@ -53,15 +56,16 @@ Ranza.prototype.watch = function(install) {
 }
 
 Ranza.prototype.exec = function() {
+    var self = this;
     r.sentinel('/').spread(function(files, root){
         var searcher = r.searcher(files),
             requires = r.formater(searcher['requires']);
-
-        return r.compare(root, requires)
+            console.log(self.debug);
+        return r.compare(root, requires, {debug: self.debug, where: searcher.where})
             .spread(function(diffs, unused, reqs, log) {
                 console.log(log + '\n');
             });
-            
+
     }).catch(function(err){
         console.log(colorizer('error', 'Ranza: ' + err ));
     })


### PR DESCRIPTION
``` sh
ranza status --debug
```

or

``` sh
ranza status -d
```

Output

``` shell
Defined and used:
  • babel-core
     => lib/new.js

  • bluebird
     => core/src/comparer.js
     => core/src/manager.js
     => core/src/sentinel.js

  • fs-readdir-recursive
     => lib/new.js

  • glob
     => core/src/sentinel.js

  • lodash
     => lib/new.js

  • node-watch
     => core/src/sentinel.js
     => lib/ranza.js

  • supports-color
     => core/src/colorizer.js


 Defined, but unused:
  • grunt
  • babel
```
